### PR TITLE
Add custom subclasses for scale, ticker, formatter for octaves

### DIFF
--- a/examples/gallery/tone-complex.py
+++ b/examples/gallery/tone-complex.py
@@ -36,7 +36,7 @@ tone_complex = stim.ramped_tone(
 tone_complex = tone_complex.sum(axis=0)
 
 ###############################################################################
-# Calculate an offset such that the tone is centeredi n the time plot.
+# Calculate an offset such that the tone is centered in the time plot.
 t = np.arange(len(tone_complex)) / fs * 1e3
 
 figure, axes = plt.subplots(1, 2, figsize=(8, 4))
@@ -47,13 +47,13 @@ axes[0].set_ylabel('Amplitude (Pascals)')
 
 psd = util.patodb(util.psd_df(tone_complex, fs))
 
-axes[1].semilogx(psd)
+###############################################################################
+# Plot the spectrum. Note the use of psiaudio's custom scale to show ticks on
+# an octave scale.
+axes[1].plot(psd)
+axes[1].set_xscale('octave')
+axes[1].axis(xmin=250, xmax=16e3, ymin=0, ymax=100)
 
-ticks = util.octave_space(250, 16e3, 1)
-axes[1].axis(xmin=ticks[0], xmax=ticks[-1], ymin=0, ymax=100)
-axes[1].set_xticks(ticks)
-axes[1].set_xticklabels(f'{t*1e-3:.2f}' for t in ticks)
-axes[1].set_xticks([], minor=True)
 axes[1].set_xlabel('Frequency (kHz)')
 axes[1].set_ylabel('Amplitude (dB SPL)')
 

--- a/examples/gallery/tone-pips.py
+++ b/examples/gallery/tone-pips.py
@@ -23,7 +23,7 @@ tone1 = stim.ramped_tone(
     fs=fs,
     duration=5e-3,
     rise_time=0.5e-3,
-    frequency=5e3,
+    frequency=2e3,
     level=94,
     calibration=cal,
 )
@@ -34,7 +34,7 @@ tone1 = stim.ramped_tone(
 tone2 = stim.ramped_tone(
     fs=fs,
     duration=5e-3,
-    frequency=5e3,
+    frequency=2e3,
     level=94,
     calibration=cal,
 )
@@ -55,11 +55,11 @@ axes[1].semilogx(psd1, label='0.5 msec rise/fall')
 axes[1].semilogx(psd2, label='2.5 msec rise/fall')
 axes[1].axhline(94, ls=':')
 
-ticks = util.octave_space(250, 16e3, 1)
-axes[1].axis(xmin=ticks[0], xmax=ticks[-1], ymin=0, ymax=100)
-axes[1].set_xticks(ticks)
-axes[1].set_xticklabels(f'{t*1e-3:.2f}' for t in ticks)
-axes[1].set_xticks([], minor=True)
+###############################################################################
+# Format the axes. Note the use of psiaudio's custom scale to show ticks on an
+# octave scale.
+axes[1].set_xscale('octave')
+axes[1].axis(xmin=250, xmax=16e3, ymin=0, ymax=100)
 axes[1].set_xlabel('Frequency (kHz)')
 axes[1].set_ylabel('Amplitude (dB SPL)')
 axes[1].legend()

--- a/psiaudio/__init__.py
+++ b/psiaudio/__init__.py
@@ -20,3 +20,10 @@ def add_logging_level(name, level):
 add_logging_level('TRACE', 5)
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
+
+
+try:
+    # Ensure that we register the OctaveScale
+    from . import plot
+except ImportError:
+    pass

--- a/psiaudio/plot.py
+++ b/psiaudio/plot.py
@@ -1,0 +1,84 @@
+'''
+Defines custom scales that may be useful for plotting audio data
+
+Example
+-------
+
+To set the x-axis to show ticks at octave intervals but ensure that the label
+SI unit is in kHz even if the data SI unit is in Hz:
+
+>>> ax.set_xscale('octave', octaves=0.5, data_si='', label_si='k')
+
+
+'''
+from psiaudio.util import octave_space
+from matplotlib import ticker as mticker
+from matplotlib import scale as mscale
+
+# Factor to multiply tick location by to transform from data SI prefix to label
+# SI prefix.
+UNIT_CONVERSION = {
+    ('', 'k'):  1e-3,
+    ('', ''):   1,
+    ('k', 'k'): 1,
+    ('k', ''):  1e3,
+}
+
+
+class OctaveLocator(mticker.Locator):
+
+    def __init__(self, octaves, data_si='', label_si='k', mode='nearest'):
+        self.octaves = octaves
+        self.data_si = data_si
+        self.label_si = label_si
+        self.conv = UNIT_CONVERSION[data_si, label_si]
+        self.mode = mode
+
+    def __call__(self):
+        """Return the locations of the ticks"""
+        bounds = self.axis.get_view_interval() * self.conv
+        return self.tick_values(*bounds) / self.conv
+
+    def tick_values(self, vmin, vmax):
+        return octave_space(vmin, vmax, self.octaves, self.mode)
+
+
+class OctaveFormatter(mticker.Formatter):
+
+    def __init__(self, data_si='', label_si='k'):
+        self.conv = UNIT_CONVERSION[data_si, label_si]
+
+    def __call__(self, x, pos=None):
+        label_x = x * self.conv
+        if label_x >= 1:
+            label_x = round(label_x)
+        return f'{label_x}'
+
+
+class OctaveScale(mscale.ScaleBase):
+
+    name = 'octave'
+
+    def __init__(self, axis, *, octaves=1, mode='nearest', data_si='', label_si='k'):
+        super().__init__(axis)
+        self.octaves = octaves
+        self.mode = mode
+        self.data_si = data_si
+        self.label_si = label_si
+
+    def get_transform(self):
+        return mscale.LogTransform(2)
+
+    def set_default_locators_and_formatters(self, axis):
+        axis.set_major_locator(OctaveLocator(self.octaves, self.data_si,
+                                             self.label_si, self.mode))
+        axis.set_major_formatter(OctaveFormatter(self.data_si, self.label_si))
+        axis.set_minor_locator(mticker.NullLocator())
+        axis.set_minor_formatter(mticker.NullFormatter())
+
+    def limit_range_for_scale(self, vmin, vmax, minpos):
+        return (minpos if vmin <= 0 else vmin,
+                minpos if vmax <= 0 else vmax)
+
+
+mscale.register_scale(OctaveScale)

--- a/psiaudio/util.py
+++ b/psiaudio/util.py
@@ -595,7 +595,7 @@ def octave_space(lb, ub, step, mode='nearest'):
         lbi = np.ceil(np.log2(lb) / step) * step
         ubi = np.floor(np.log2(ub) / step) * step
     x = np.arange(lbi, ubi+step, step)
-    return 2**x
+    return 2.0**x
 
 
 def interleave_octaves(freqs, min_octaves=1):


### PR DESCRIPTION
This allows us to quickly format axes in units of octaves using `set_xscale('octaves')`.