### PR TITLE
Add two new noise generators and calibrate bandlimited click

### DIFF
--- a/psiaudio/calibration.py
+++ b/psiaudio/calibration.py
@@ -279,6 +279,7 @@ class InterpCalibration(BaseFrequencyCalibration):
     def get_sens(self, frequency):
         # Since sensitivity is in dB(V), subtracting fixed_gain from
         # sensitivity will *increase* the sensitivity of the system.
+        frequency = np.asarray(frequency)
         return self._interp(frequency)-self.fixed_gain
 
     def get_phase(self, frequency):


### PR DESCRIPTION
* Bandlmited click now equalizes based on calibration
* Shaped noise - uses FIR filters to create fine-tuned noise with varying gain vs. frequency profile
* Bandlimited FIR noise - This is based on shaped noise, but simpler to use (just specify low/high frequency of band).